### PR TITLE
add more support for parsing source

### DIFF
--- a/src/basic/painter.js
+++ b/src/basic/painter.js
@@ -15,8 +15,8 @@ class BasicPainter extends Painter {
   }
   renderLayer(painter, sourceCache, layer, coords) {
     let layerStylesheet = layerStylesheetFromLayer(layer);
-    if (layerStylesheet && layerStylesheet.minzoom_ && this._filterForZoom < layerStylesheet.minzoom_) return;
-    if (layerStylesheet && layerStylesheet.maxzoom_ && this._filterForZoom >= layerStylesheet.maxzoom_) return;
+    if (layerStylesheet && layerStylesheet.minzoom_ && coords[0].overscaledZ < layerStylesheet.minzoom_) return;
+    if (layerStylesheet && layerStylesheet.maxzoom_ && coords[0].overscaledZ >= layerStylesheet.maxzoom_) return;
     super.renderLayer(painter, sourceCache, layer, coords);
   }
 };

--- a/src/basic/renderer.js
+++ b/src/basic/renderer.js
@@ -8,7 +8,8 @@ const BasicPainter = require('./painter'),
       QueryFeatures = require('../source/query_features'),
       EvaluationParameters = require('../style/evaluation_parameters'),
       Placement = require('../symbol/placement'),
-      assert = require('assert');
+      assert = require('assert'),
+      stylePreprocess = require('./stylePerprocess');
 
 const DEFAULT_RESOLUTION = 256;
 const OFFSCREEN_CANV_SIZE = 1024; 
@@ -38,6 +39,7 @@ class MapboxBasicRenderer extends Evented {
       tileZoom: tile => tile.tileID.canonical.z,
       calculatePosMatrix: tileID => tileID.posMatrix 
     };
+    stylePreprocess(options.style);
     this._initStyle = options.style;
     this._style = new BasicStyle(Object.assign({}, options.style, {transition: {duration: 0}}), this);
     this._style.setEventedParent(this, {style: this._style});

--- a/src/basic/renderer.js
+++ b/src/basic/renderer.js
@@ -209,7 +209,8 @@ class MapboxBasicRenderer extends Evented {
       return;
     }
     this.painter._filterForZoom = zoom;
-    this._cancelAllPendingRenders();
+    // don't cancel pending render because it may renders tiles with different zoom at the same time.
+    // this._cancelAllPendingRenders();
     return;
   }
 

--- a/src/basic/source_cache.js
+++ b/src/basic/source_cache.js
@@ -7,7 +7,7 @@ const Cache = require('../util/lru_cache'),
    
 let sphericalMercator = new SphericalMercator();
 
-const TILE_CACHE_SIZE = 100;
+const TILE_CACHE_SIZE = 20;
 
 const TILE_LOAD_TIMEOUT = 60*1000;
 

--- a/src/basic/style.js
+++ b/src/basic/style.js
@@ -17,6 +17,8 @@ class BasicStyle extends Style {
     source_.setEventedParent(this, {source: source_});
     source_.map = this.map;
     source_.tiles = source.tiles;
+    source_.load()
+    this.loadedPromise.then(() => new Promise(res => source_.on('data', e => e.dataType === 'source' && res())));
     this.sourceCaches[id] = new BasicSourceCache(source_);
   }
   

--- a/src/basic/stylePerprocess.js
+++ b/src/basic/stylePerprocess.js
@@ -1,0 +1,21 @@
+module.exports = function mvtStylePreprocess(style) {
+  if (typeof style !== 'object') return;
+  if (!Array.isArray(style.layers)) return;
+
+  // minzoom/maxzoom to minzoom_/maxzoom_
+  style.layers.forEach((layer) => {
+    if (typeof layer.minzoom === 'number') {
+      layer.minzoom_ = layer.minzoom
+      delete layer.minzoom
+    }
+    if (typeof layer.maxzoom === 'number') {
+      layer.maxzoom_ = layer.maxzoom
+      delete layer.maxzoom
+    }
+  })
+
+  // delete raster layer
+  style.layers = style.layers.filter(l => {
+   return l.type !== 'raster' || l.type !== 'background'
+  })
+}

--- a/src/basic/stylePerprocess.js
+++ b/src/basic/stylePerprocess.js
@@ -16,6 +16,6 @@ module.exports = function mvtStylePreprocess(style) {
 
   // delete raster layer
   style.layers = style.layers.filter(l => {
-   return l.type !== 'raster' || l.type !== 'background'
+   return l.type !== 'raster' && l.type !== 'background'
   })
 }


### PR DESCRIPTION
call VectorTileSource.load method to parse Source to support more options described in mapbox style specification. for example, sources: { 'test': {url: "http://eaxmple.com/style.json", type: "vector"}} now could be load correctly.