### PR TITLE
[SC-14467]: Check cache before assigning `featuresByRenderLayer` value

### DIFF
--- a/src/basic/renderer.js
+++ b/src/basic/renderer.js
@@ -414,24 +414,25 @@ class MapboxBasicRenderer extends Evented {
   queryRenderedFeatures(opts){
     assert(opts.source);
 
-    let layers = {};
-    this.getLayersVisible(opts.renderedZoom, opts.source)
-        .forEach(lyr => layers[lyr] = this._style._layers[lyr]);
+    const layers = {};
+    const cache = this._style.sourceCaches[opts.source];
 
-    let featuresByRenderLayer = QueryFeatures.rendered(
-      this._style.sourceCaches[opts.source],
-      layers, 
-      opts, 
-      {}, opts.tileZ, 0);
+    this
+      .getLayersVisible(opts.renderedZoom, opts.source)
+      .forEach(lyr => layers[lyr] = this._style._layers[lyr]);
+    
+    const featuresByRenderLayer = !cache ? {} : QueryFeatures.rendered(cache, layers, opts, {}, opts.tileZ, 0); 
 
-    let featuresBySourceLayer = {};
+    const featuresBySourceLayer = {};
     Object.keys(featuresByRenderLayer)
       .forEach(renderLayerName => 
         featuresByRenderLayer[renderLayerName].map(renderLayerFeatures => {
-          let lyr = featuresBySourceLayer[renderLayerFeatures.layer['source-layer']]
-                  = (featuresBySourceLayer[renderLayerFeatures.layer['source-layer']] || []);
-          lyr.push(renderLayerFeatures._vectorTileFeature.properties)
-        }));    
+          const sourceLayerName = renderLayerFeatures.layer['source-layer'];
+          const layer = featuresBySourceLayer[sourceLayerName]
+                  = (featuresBySourceLayer[sourceLayerName] || []);
+          layer.push(renderLayerFeatures._vectorTileFeature.properties)
+        }));
+
     return featuresBySourceLayer;
   }
 


### PR DESCRIPTION
A large number of errors are being thrown when trying to read `tilesIn` from the cache:
```
Cannot read properties of undefined (reading 'tilesIn')
```

**Steps to reproduce**:
1. Refresh the app with the mouse hovering over the map
2. Move the cursor before the map has finished rendering

Whilst this isn't creating any obvious problems for consumers of this package it will help to reduce noise & uncaught exceptions being thrown.

## Launch Checklist


<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] manually test the debug page
